### PR TITLE
Fix crash when an enemy's hitpoints exceed its max

### DIFF
--- a/Construction/src/patches/skillPatches/combat/patchOverHeal.mjs
+++ b/Construction/src/patches/skillPatches/combat/patchOverHeal.mjs
@@ -218,7 +218,7 @@ export function patchOverHeal(ctx) {
     // make it look professional
     SplashManager.splashClasses.Overheal = 'construction-success';
     ctx.patch(Character, 'renderHitpoints').after(function (_) {
-        const isOverheal = this.hitpoints > this.stats.maxHitpoints;
+        const isOverheal = this instanceof Player && this.hitpoints > this.stats.maxHitpoints;
 
         if (isOverheal) {
             const overPercent = (Math.min((this.hitpoints / this.stats.maxHitpoints) - 1, 1) * 100).toFixed(1);


### PR DESCRIPTION
### Problem

`patchOverHeal` installs the overheal render effect on `Character`:

```js
ctx.patch(Character, 'renderHitpoints').after(function (_) {
    const isOverheal = this.hitpoints > this.stats.maxHitpoints;
```

`Character` is the base of both `Player` and `Enemy`, so this also runs for enemies. The DOM walk inside it only matches the player's HP bar markup:

```js
this.statElements.hitpointsBar[0].parentElement.parentElement.parentElement.children[3]...
```

For an enemy that ancestor has no fourth child, so `children[3]` is `undefined` and reading `.children` off it throws, which kills the combat render loop:

```
TypeError: Cannot read properties of undefined (reading 'children')
    at Construction:src/patches/skillPatches/combat/patchOverHeal.mjs:236:105
    at Enemy.<anonymous> (patchOverHeal.mjs:226:44)
    at Enemy.renderHitpoints (enemy.js:363:19)
    at CombatManager.render (combatManager.js:304:15)
```

Line 237 has the same problem — `hitpointsBar[2]` is the thieving bar, which enemies also don't have.

It only shows up once something can push a character above its max HP, so in practice it starts after the Pantry (`Fridge3`) grants `unlockOverHeal`.

### Fix

Gate the effect on `Player`, which is the only thing the mod overheals and the only markup the DOM walk targets.

This also fixes a second, quieter issue: enemies were getting the orange gradient painted onto their HP bar, and it was never cleared, because `displayOverheal` is only reset in the player's branch.

Reported against v1.0.5; still present on `master`.
